### PR TITLE
FIX: non-latin headers

### DIFF
--- a/flatdoc.js
+++ b/flatdoc.js
@@ -428,7 +428,9 @@ Also includes:
   }
 
   function slugify(text) {
-    return text.toLowerCase().match(/[a-z0-9]+/g).join('-');
+    var match = text.toLowerCase().match(/[a-z0-9]+/g);
+    match = (match===null) ? [new Date().getTime()] : match;
+    return match.join('-');
   }
 })(jQuery);
 /*!


### PR DESCRIPTION
**Problem:**
if the "text" value passed to "slugify" function consist only non-latin characters (cyrillic, for example), regular expression match === null. And we get an error on "join('-')".  
**Solution:**
I assigned to match result (if match===null) a timestamp. This solution a little bad for the semantics,  but completely solve the problem
