### PR TITLE
Fixed sticky sidebar when resizing

### DIFF
--- a/src/flatdoc.js
+++ b/src/flatdoc.js
@@ -202,7 +202,7 @@ Also includes:
       var $el = $(this);
       var level = +(this.nodeName.substr(1));
 
-      parent = mkdir_p(level-1);
+      var parent = mkdir_p(level-1);
 
       var obj = { section: $el.text(), items: [], level: level, id: $el.attr('id') };
       parent.items.push(obj);

--- a/theme-white/script.js
+++ b/theme-white/script.js
@@ -56,17 +56,17 @@
    * Sidebar stick.
    */
 
-  $(function () {
-    var $sidebar = $('.menubar'),
-      elTop;
+  $(function() {
+    var $sidebar = $('.menubar');
+    var elTop;
 
     $window
-      .on('resize.sidestick', function () {
+      .on('resize.sidestick', function() {
         $sidebar.removeClass('fixed');
         elTop = $sidebar.offset().top;
         $window.trigger('scroll.sidestick');
       })
-      .on('scroll.sidestick', function () {
+      .on('scroll.sidestick', function() {
         var scrollY = $window.scrollTop();
         $sidebar.toggleClass('fixed', (scrollY >= elTop));
       })

--- a/theme-white/script.js
+++ b/theme-white/script.js
@@ -56,22 +56,22 @@
    * Sidebar stick.
    */
 
-    $(function () {
-      var $sidebar = $('.menubar'),
-        elTop;
+  $(function () {
+    var $sidebar = $('.menubar'),
+      elTop;
 
-      $window
-        .on('resize.sidestick', function () {
-          $sidebar.removeClass('fixed');
-          elTop = $sidebar.offset().top;
-          $window.trigger('scroll.sidestick');
-        })
-        .on('scroll.sidestick', function () {
-          var scrollY = $window.scrollTop();
-          $sidebar.toggleClass('fixed', (scrollY >= elTop));
-        })
-        .trigger('resize.sidestick');
-    });
+    $window
+      .on('resize.sidestick', function () {
+        $sidebar.removeClass('fixed');
+        elTop = $sidebar.offset().top;
+        $window.trigger('scroll.sidestick');
+      })
+      .on('scroll.sidestick', function () {
+        var scrollY = $window.scrollTop();
+        $sidebar.toggleClass('fixed', (scrollY >= elTop));
+      })
+      .trigger('resize.sidestick');
+  });
 
 })(jQuery);
 /*! jQuery.scrollagent (c) 2012, Rico Sta. Cruz. MIT License.

--- a/theme-white/script.js
+++ b/theme-white/script.js
@@ -56,21 +56,22 @@
    * Sidebar stick.
    */
 
-  $(function() {
-    var $sidebar = $('.menubar');
-    var elTop;
+    $(function () {
+      var $sidebar = $('.menubar'),
+        elTop;
 
-    $window
-      .on('resize.sidestick', function() {
-        elTop = $sidebar.offset().top;
-        $window.trigger('scroll.sidestick');
-      })
-      .on('scroll.sidestick', function() {
-        var scrollY = $window.scrollTop();
-        $sidebar.toggleClass('fixed', (scrollY >= elTop));
-      })
-      .trigger('resize.sidestick');
-  });
+      $window
+        .on('resize.sidestick', function () {
+          $sidebar.removeClass('fixed');
+          elTop = $sidebar.offset().top;
+          $window.trigger('scroll.sidestick');
+        })
+        .on('scroll.sidestick', function () {
+          var scrollY = $window.scrollTop();
+          $sidebar.toggleClass('fixed', (scrollY >= elTop));
+        })
+        .trigger('resize.sidestick');
+    });
 
 })(jQuery);
 /*! jQuery.scrollagent (c) 2012, Rico Sta. Cruz. MIT License.


### PR DESCRIPTION
1. Scroll down so that the sidebar becomes sticky
2. Resize the window
3. Scroll up, the sidebar gets static

When calculating the upper offset, the sidebar has to be static.
