### PR TITLE
Fix for HTML Keyword highlighting.

### DIFF
--- a/flatdoc.js
+++ b/flatdoc.js
@@ -327,7 +327,7 @@ Also includes:
       .replace(/("[^\"]*?")/g, '<span class="string">$1</span>')
       .replace(/('[^\']*?')/g, '<span class="string">$1</span>')
       .replace(/&lt;!--(.*)--&gt;/g, '<span class="comment">&lt;!--$1--&gt;</span>')
-      .replace(/&lt;([^!][^ ]*)/g, '&lt;<span class="keyword">$1</span>');
+      .replace(/&lt;([^!][^\s&]*)/g, '&lt;<span class="keyword">$1</span>');
   };
 
   Highlighters.generic = function(code) {

--- a/src/flatdoc.js
+++ b/src/flatdoc.js
@@ -279,7 +279,7 @@ Also includes:
       .replace(/("[^\"]*?")/g, '<span class="string">$1</span>')
       .replace(/('[^\']*?')/g, '<span class="string">$1</span>')
       .replace(/&lt;!--(.*)--&gt;/g, '<span class="comment">&lt;!--$1--&gt;</span>')
-      .replace(/&lt;([^!][^ ]*)/g, '&lt;<span class="keyword">$1</span>');
+      .replace(/&lt;([^!][^\s&]*)/g, '&lt;<span class="keyword">$1</span>');
   };
 
   Highlighters.generic = function(code) {


### PR DESCRIPTION
The keyword highlighting in HTML code is broken if there are not attributes for a tag!

The following markdown code:

``````
```html
<div>Test</div>
```
``````

will create:

```
<pre>
    <code class="lang-html">
    &lt;<span class="keyword">div&gt;test&lt;/div&gt;</span>
    </code>
</pre>
```

which looks like this:

&lt;**div&gt;Test&lt;/div&gt;**

instead of:

```
<pre>
    <code class="lang-html">
    &lt;<span class="keyword">div</span>&gt;test&lt;<span class="keyword">/div</span>&gt;
    </code>
</pre>
```

which looks like this:

&lt;**div**&gt;Test&lt;**/div**&gt;

This was pretty easy to fix by just adding the & (of &amp;gt;) as additional end besides of a space. I also changed the space to the /s regex so it also works in the (possible) case that a tag continues with a line break or a tab character.
