### PR TITLE
Qualify slugs with those from parent headings

### DIFF
--- a/flatdoc.js
+++ b/flatdoc.js
@@ -211,11 +211,15 @@ Also includes:
    */
 
   Transformer.addIDs = function($content) {
+    var slugs = ['', '', ''];
     $content.find('h1, h2, h3').each(function() {
       var $el = $(this);
+      var num = parseInt(this.nodeName[1]);
       var text = $el.text();
-      var id = slugify(text);
-      $el.attr('id', id);
+      var slug = slugify(text);
+      slugs[num - 1] = slug;
+      if (num > 1) slug = slugs[num - 2] + '-' + slug;
+      $el.attr('id', slug);
     });
   };
 

--- a/flatdoc.js
+++ b/flatdoc.js
@@ -217,8 +217,9 @@ Also includes:
       var num = parseInt(this.nodeName[1]);
       var text = $el.text();
       var slug = slugify(text);
-      slugs[num - 1] = slug;
       if (num > 1) slug = slugs[num - 2] + '-' + slug;
+      slugs.length = num - 1;
+      slugs = slugs.concat([slug, slug]);
       $el.attr('id', slug);
     });
   };

--- a/test/transform_test.js
+++ b/test/transform_test.js
@@ -11,7 +11,7 @@ describe("Flatdoc.transformer", function() {
     trans.addIDs($html);
 
     $html.find('h1').attr('id').should.equal('hello');
-    $html.find('h2').attr('id').should.equal('one-two-three');
+    $html.find('h2').attr('id').should.equal('hello-one-two-three');
   });
 
   it(".buttonize()", function() {


### PR DESCRIPTION
In the example below, the `<h2>` element would get an id `"hello-one-two-three"`.

```
<div><h1>Hello</h1><h2>One Two &amp; Three</h2>
```

This solves a problem where headings with the same text would get the same id (which is invalid and breaks navigation).

![michael-jackson-eating-popcorn-o](https://cloud.githubusercontent.com/assets/26405/3286991/5c061d90-f551-11e3-9acc-9ff70696dc4a.gif)

This closes https://github.com/rstacruz/flatdoc/issues/32.
