### PR TITLE
Fix get menu with non sequential headings

### DIFF
--- a/flatdoc.js
+++ b/flatdoc.js
@@ -236,14 +236,14 @@ Also includes:
     var cache = [root];
 
     function mkdir_p(level) {
-      var parent = (level > 1) ? mkdir_p(level-1) : root;
-      if (!cache[level]) {
+      var obj = cache[level];
+      if (!obj) {
+        var parent = (level > 1) ? mkdir_p(level-1) : root;
         var obj = { items: [], level: level };
         cache[level] = obj;
         parent.items.push(obj);
-        return obj;
       }
-      return cache[level];
+      return obj;
     }
 
     $content.find('h1, h2, h3').each(function() {

--- a/flatdoc.js
+++ b/flatdoc.js
@@ -240,7 +240,8 @@ Also includes:
       if (!obj) {
         var parent = (level > 1) ? mkdir_p(level-1) : root;
         var obj = { items: [], level: level };
-        cache[level] = obj;
+        cache.length = level + 1;
+        cache = cache.concat([obj, obj]);
         parent.items.push(obj);
       }
       return obj;


### PR DESCRIPTION
This patch fixes an issue arising when e.g. an `<h3>` follows an `<h1>` immediately – that is, without an `<h2>` in-between.
