### PR TITLE
Fixes #31 navbar offset with images

### DIFF
--- a/theme-white/script.js
+++ b/theme-white/script.js
@@ -110,10 +110,10 @@
         (options.offset || 0);
 
       offsets.push({
-        top: $(this).offset().top + offset,
         id: $(this).attr('id'),
         index: i,
-        el: this
+        el: this,
+        offset: offset
       });
     });
 
@@ -139,7 +139,7 @@
       for (var i in offsets) {
         if (offsets.hasOwnProperty(i)) {
           var offset = offsets[i];
-          if (offset.top < y) latest = offset;
+          if ($(offset.el).offset().top + offset.offset < y) latest = offset;
         }
       }
 


### PR DESCRIPTION
fixes #31 

checks for section offset on scroll instead of at the beginning before images load.
