### PR TITLE
Add support for non-default github branches

### DIFF
--- a/Reference.md
+++ b/Reference.md
@@ -31,7 +31,9 @@ Github fetcher.
 Fetches from repo `repo` (in format 'user/repo').
 
 If the parameter `filepath` is supplied, it fetches the contents of that
-given file in the repo.
+given file in the repo's default branch. To fetch the contents of
+`filepath` from a different branch, the parameter `ref` should be
+supplied with the target branch name.
 
 See [Runner#run()] for a description of fetcher functions.
 

--- a/flatdoc.js
+++ b/flatdoc.js
@@ -50,18 +50,23 @@
    * Fetches from repo `repo` (in format 'user/repo').
    *
    * If the parameter `filepath` is supplied, it fetches the contents of that
-   * given file in the repo.
+   * given file in the repo's default branch. To fetch the contents of
+   * `filepath` from a different branch, the parameter `ref` should be
+   * supplied with the target branch name.
    *
    * See [Runner#run()] for a description of fetcher functions.
    *
    * See: http://developer.github.com/v3/repos/contents/
    */
-  Flatdoc.github = function(repo, filepath) {
+  Flatdoc.github = function(repo, filepath, ref) {
     var url;
     if (filepath) {
       url = 'https://api.github.com/repos/'+repo+'/contents/'+filepath;
     } else {
       url = 'https://api.github.com/repos/'+repo+'/readme';
+    }
+    if (ref) {
+      url += '?ref='+ref;
     }
     return function(callback) {
       $.get(url)

--- a/src/flatdoc.js
+++ b/src/flatdoc.js
@@ -58,20 +58,25 @@ Also includes:
   /**
    * Github fetcher.
    * Fetches from repo `repo` (in format 'user/repo').
-   * 
+   *
    * If the parameter `filepath` is supplied, it fetches the contents of that
-   * given file in the repo.
+   * given file in the repo's default branch. To fetch the contents of
+   * `filepath` from a different branch, the parameter `ref` should be
+   * supplied with the target branch name.
    *
    * See [Runner#run()] for a description of fetcher functions.
    *
    * See: http://developer.github.com/v3/repos/contents/
    */
-  Flatdoc.github = function(repo, filepath) {
+  Flatdoc.github = function(repo, filepath, ref) {
     var url;
     if (filepath) {
       url = 'https://api.github.com/repos/'+repo+'/contents/'+filepath;
     } else {
       url = 'https://api.github.com/repos/'+repo+'/readme';
+    }
+    if (ref) {
+      url += '?ref='+ref;
     }
     return function(callback) {
       $.get(url)


### PR DESCRIPTION
This allows users to specify branch names like so:

```
Flatdoc.run({ fetcher: Flatdoc.github('coinsph/api', 'README.md', 'gh-pages') })
```

which means, the default branch can stay as `master` and `gh-pages` as an orphan branch. The `ref` parameter is further described [here](https://developer.github.com/v3/repos/contents/#get-contents).
