### PR TITLE
Error event hook

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -190,7 +190,7 @@ Here are some ideas to get you started.
 
 ### JavaScript hooks
 
-Flatdoc emits the events `flatdoc:loading` and `flatdoc:ready` to help you make
+Flatdoc emits the events `flatdoc:loading`, `flatdoc:error` and `flatdoc:ready` to help you make
 custom behavior when the document loads.
 
 ``` js

--- a/flatdoc.js
+++ b/flatdoc.js
@@ -458,6 +458,7 @@
     $(doc.root).trigger('flatdoc:loading');
     doc.fetcher(function(err, markdown) {
       if (err) {
+        $(doc.root).trigger('flatdoc:error', err);
         console.error('[Flatdoc] fetching Markdown data failed.', err);
         return;
       }


### PR DESCRIPTION
Great tool! 

I got a couple of 404 errors because I renamed a document, and in this case I could use an event hook to execute a custom action.

Whenever a file fails to load, flatdoc fails silently, so it would be interesting to fire an event signaling a load error. 

The user could display a 404 text, or load another page in case of errors...
