### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
     "theme-white/script.js",
     "theme-white/style.css"
   ],
-  "version": "0.9.0",
   "homepage": "https://github.com/rstacruz/flatdoc",
   "authors": [
     "Rico Sta. Cruz <hi@ricostacruz.com>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property
