### PR TITLE
andSelf() is deprecated in jQuery > 3.0

### DIFF
--- a/flatdoc.js
+++ b/flatdoc.js
@@ -519,7 +519,9 @@
   // http://stackoverflow.com/questions/298750/how-do-i-select-text-nodes-with-jquery
   function getTextNodesIn(el) {
     var exclude = 'iframe,pre,code';
-    return $(el).find(':not('+exclude+')').andSelf().contents().filter(function() {
+    // andSelf is deprecated in jQuery > 3.0
+    var back = $.fn.addBack ? 'addBack' : 'andSelf';
+    return $(el).find(':not('+exclude+')')[back]().contents().filter(function() {
       return this.nodeType == 3 && $(this).closest(exclude).length === 0;
     });
   }


### PR DESCRIPTION
andSelf() was removed, you can still use jquery.migrate to prevent broken flatdoc with jquery 3 til this pull is accepted
